### PR TITLE
Make notifications dropdown mobile-friendly

### DIFF
--- a/src/components/notification_center.tsx
+++ b/src/components/notification_center.tsx
@@ -40,10 +40,10 @@ const NotificationItem: React.FC<{
     <button
       onClick={handleClick}
       className={classNames(
-        "w-full text-left px-3 py-3 transition-all border-b border-border-default last:border-b-0",
+        "w-full text-left px-4 py-3 sm:px-3 sm:py-3 transition-all border-b border-border-default last:border-b-0 active:scale-[0.99]",
         notification.read
-          ? "bg-transparent hover:bg-surface-hover"
-          : "bg-primary/5 hover:bg-primary/10"
+          ? "bg-transparent hover:bg-surface-hover active:bg-surface-hover"
+          : "bg-primary/5 hover:bg-primary/10 active:bg-primary/10"
       )}
     >
       <div className="flex items-start gap-3">
@@ -56,16 +56,16 @@ const NotificationItem: React.FC<{
         <div className="flex-1 min-w-0">
           <p
             className={classNames(
-              "text-sm font-medium truncate",
+              "text-sm sm:text-sm font-medium line-clamp-2 sm:truncate",
               notification.read ? "text-text-secondary" : "text-text-primary"
             )}
           >
             {notification.title}
           </p>
-          <p className="text-xs text-text-tertiary mt-0.5 line-clamp-2">
+          <p className="text-xs text-text-tertiary mt-1 line-clamp-2">
             {notification.message}
           </p>
-          <p className="text-xs text-text-muted mt-1">
+          <p className="text-xs text-text-muted mt-1.5">
             {formatTimeAgo(notification.created_at)}
           </p>
         </div>
@@ -131,23 +131,44 @@ export const NotificationCenter: React.FC = () => {
       {isOpen && (
         <>
           <div
-            className="fixed inset-0 z-10"
+            className="fixed inset-0 z-10 bg-black/20 sm:bg-transparent"
             onClick={() => setIsOpen(false)}
           />
-          <div className="absolute right-0 mt-2 w-80 sm:w-96 rounded-2xl bg-bg-tertiary border border-border-default shadow-primary-lg z-20 overflow-hidden">
+          <div className="fixed sm:absolute left-4 right-4 sm:left-auto sm:right-0 top-16 sm:top-auto sm:mt-2 max-w-md sm:w-96 rounded-2xl bg-bg-tertiary border border-border-default shadow-primary-lg z-20 overflow-hidden">
             <div className="flex items-center justify-between px-4 py-3 border-b border-border-default">
               <h3 className="font-semibold text-text-primary">Notifications</h3>
-              {unreadCount > 0 && (
+              <div className="flex items-center gap-2">
+                {unreadCount > 0 && (
+                  <button
+                    onClick={handleMarkAllAsRead}
+                    className="text-xs text-primary hover:text-primary-light transition-colors"
+                  >
+                    Mark all as read
+                  </button>
+                )}
                 <button
-                  onClick={handleMarkAllAsRead}
-                  className="text-xs text-primary hover:text-primary-light transition-colors"
+                  onClick={() => setIsOpen(false)}
+                  className="sm:hidden flex items-center justify-center w-8 h-8 rounded-full hover:bg-surface-hover transition-colors"
+                  aria-label="Close notifications"
                 >
-                  Mark all as read
+                  <svg
+                    className="w-5 h-5 text-text-secondary"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M6 18L18 6M6 6l12 12"
+                    />
+                  </svg>
                 </button>
-              )}
+              </div>
             </div>
 
-            <div className="max-h-96 overflow-y-auto">
+            <div className="max-h-[60vh] sm:max-h-96 overflow-y-auto">
               {notifications.length === 0 ? (
                 <div className="px-4 py-8 text-center">
                   <svg

--- a/src/components/theme_switcher.tsx
+++ b/src/components/theme_switcher.tsx
@@ -19,7 +19,7 @@ export const ThemeSwitcher: React.FC = () => {
     <div className="relative">
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center gap-2 px-3 sm:px-4 py-1.5 sm:py-2 rounded-full bg-surface hover:bg-surface-hover border border-border-default hover:border-border-hover text-text-primary transition-all text-sm font-medium active:scale-95"
+        className="flex items-center gap-2 h-9 sm:h-10 px-3 sm:px-4 rounded-full bg-surface hover:bg-surface-hover border border-border-default hover:border-border-hover text-text-primary transition-all text-sm font-medium active:scale-95"
         aria-label="Switch theme"
       >
         <span className="text-base">{currentTheme.icon}</span>

--- a/src/pages/homepage.tsx
+++ b/src/pages/homepage.tsx
@@ -159,7 +159,7 @@ export const Homepage: React.FC = () => {
                 <NotificationCenter />
                 <button
                   onClick={copyShareLink}
-                  className="flex items-center gap-1.5 sm:gap-2 px-3 sm:px-4 py-1.5 sm:py-2 rounded-full bg-surface hover:bg-surface-hover border border-border-default hover:border-border-hover text-text-secondary hover:text-text-primary transition-all text-sm font-medium active:scale-95"
+                  className="flex items-center gap-1.5 sm:gap-2 h-9 sm:h-10 px-3 sm:px-4 rounded-full bg-surface hover:bg-surface-hover border border-border-default hover:border-border-hover text-text-secondary hover:text-text-primary transition-all text-sm font-medium active:scale-95"
                 >
                   <svg
                     className="w-3.5 h-3.5 sm:w-4 sm:h-4"
@@ -178,7 +178,7 @@ export const Homepage: React.FC = () => {
                 </button>
                 <button
                   onClick={handleLogout}
-                  className="flex items-center gap-1.5 sm:gap-2 px-3 sm:px-4 py-1.5 sm:py-2 rounded-full bg-surface hover:bg-surface-hover border border-border-default hover:border-border-hover text-text-secondary hover:text-text-primary transition-all text-sm font-medium active:scale-95"
+                  className="flex items-center gap-1.5 sm:gap-2 h-9 sm:h-10 px-3 sm:px-4 rounded-full bg-surface hover:bg-surface-hover border border-border-default hover:border-border-hover text-text-secondary hover:text-text-primary transition-all text-sm font-medium active:scale-95"
                 >
                   <svg
                     className="w-3.5 h-3.5 sm:w-4 sm:h-4"


### PR DESCRIPTION
- Change dropdown to fixed positioning on mobile with proper margins
- Add semi-transparent backdrop overlay on mobile
- Adjust max height to 60vh on mobile (vs 96 on desktop) for better scrolling
- Add visible close button (X) in header for mobile users
- Improve touch targets with better padding on mobile (px-4 vs px-3)
- Allow notification titles to wrap on mobile (line-clamp-2) instead of truncate
- Add active state feedback (scale and bg) for better touch interaction
- Responsive width: full width with margins on mobile, fixed 384px on desktop