### PR TITLE
Fix streaming providers dropdown to show all available providers

### DIFF
--- a/src/api/movies.ts
+++ b/src/api/movies.ts
@@ -360,3 +360,27 @@ export const useUpdateUserProviders = () => {
     },
   });
 };
+
+export const useGetAllAvailableProviders = () => {
+  return useQuery({
+    queryKey: ["allProviders"],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("movie_providers")
+        .select("provider_name")
+        .eq("provider_type", "free")
+        .not("provider_name", "is", null);
+
+      if (error) {
+        throw new Error(error.message);
+      }
+
+      // Get unique provider names and sort them
+      const uniqueProviders = Array.from(
+        new Set(data.map((p: { provider_name: string }) => p.provider_name))
+      ).sort();
+
+      return uniqueProviders;
+    },
+  });
+};

--- a/src/api/movies.ts
+++ b/src/api/movies.ts
@@ -368,7 +368,6 @@ export const useGetAllAvailableProviders = () => {
       const { data, error } = await supabase
         .from("movie_providers")
         .select("provider_name")
-        .eq("provider_type", "free")
         .not("provider_name", "is", null);
 
       if (error) {

--- a/src/pages/homepage.tsx
+++ b/src/pages/homepage.tsx
@@ -10,8 +10,8 @@ import {
   useGetMovies,
   useGetUserProviders,
   useUpdateUserProviders,
+  useGetAllAvailableProviders,
 } from "api/movies";
-import { useMemo } from "react";
 import { Option } from "components/multi_select";
 import { useShareWatchlist } from "hooks/useShareWatchlist";
 import { supabase } from "api/database";
@@ -61,6 +61,7 @@ export const Homepage: React.FC = () => {
 
   const { data: userProviders } = useGetUserProviders(user?.id);
   const { mutate } = useUpdateUserProviders();
+  const { data: allProviders } = useGetAllAvailableProviders();
 
   const userProviderOptions = (userProviders ?? []).map(
     ({ provider_name: p }) => ({
@@ -86,18 +87,10 @@ export const Homepage: React.FC = () => {
     mutate({ providersAdded, providersToDelete });
   };
 
-  const allProviderOptions = useMemo(() => {
-    const providerSet = new Set<string>();
-    data?.movies.map((m) => {
-      const providers: string[] = m.movie_providers
-        .filter((p) => p.provider_type === "free" && Boolean(p.provider_name))
-        .map((p) => p.provider_name);
-      providers.forEach((p) => providerSet.add(p));
-    });
-    return Array.from(providerSet)
-      .sort()
-      .map((p) => ({ label: p, value: p }));
-  }, [data?.movies]);
+  const allProviderOptions = (allProviders ?? []).map((p) => ({
+    label: p,
+    value: p,
+  }));
 
   if (isLoading) {
     return (


### PR DESCRIPTION
Previously, the dropdown only showed providers that appeared in the current user's watchlist.
This caused new users with empty watchlists to see an empty dropdown.

Changes:
- Added useGetAllAvailableProviders hook in api/movies.ts to fetch all free streaming providers from the database
- Updated homepage.tsx to use the new hook instead of computing providers from the current watchlist
- Removed useMemo dependency as it's no longer needed

Now all users will see all available streaming providers in the dropdown, regardless of their watchlist content.