### PR TITLE
Show availability badge only for available trending content

### DIFF
--- a/src/components/trending_section.tsx
+++ b/src/components/trending_section.tsx
@@ -80,9 +80,7 @@ const TrendingCard: React.FC<{
 
         <p className="mt-0.5 text-text-tertiary text-xs flex items-center justify-between gap-2">
           {year && <span>{year}</span>}
-          <StateIndicator
-            state={stream.is_available ? "available" : "unavailable"}
-          />
+          {stream.is_available && <StateIndicator state="available" />}
         </p>
       </div>
     </button>


### PR DESCRIPTION
Modified the TrendingCard component to conditionally render the availability
badge only when content is available. Unavailable content now shows no badge,
providing a cleaner UI and drawing attention only to available content.