### PR TITLE
Fix trending to fetch daily instead of weekly

### DIFF
--- a/src/api/movies.ts
+++ b/src/api/movies.ts
@@ -405,16 +405,16 @@ export const useGetTrendingFiltered = (userId?: string) => {
               description,
               release_date,
               poster_path,
-              movie_providers!inner(provider_name, provider_type)
-
+              movie_providers!left(provider_name, provider_type)
             )
           `
         )
         .gt(
           "created_at",
-          new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString()
-        ) // only last 7 days
-        .order("trending_rank", { ascending: true });
+          new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString()
+        ) // only last 2 days
+        .order("created_at", { ascending: false })
+        .limit(40);
       if (error) {
         throw new Error(error.message);
       }
@@ -442,6 +442,8 @@ export const useGetTrendingFiltered = (userId?: string) => {
           is_available: isAvailable,
         };
       });
+
+      result.sort((a, b) => a.trending_rank - b.trending_rank);
 
       const movies = result.filter((item) => item.medium === "movie");
       const tvs = result.filter((item) => item.medium === "tv");

--- a/supabase/functions/refresh_trending/index.ts
+++ b/supabase/functions/refresh_trending/index.ts
@@ -104,7 +104,7 @@ async function ensureMovieExists(
 async function processTrendingForMedium(
   medium: Medium
 ): Promise<{ movie_id: number; trending_rank: number; medium: Medium }[]> {
-  const trending = await movieService.getTrending(medium, "week");
+  const trending = await movieService.getTrending(medium, "day");
 
   const results: { movie_id: number; trending_rank: number; medium: Medium }[] =
     [];

--- a/supabase/migrations/20260115000001_update_trending_unique_constraint.sql
+++ b/supabase/migrations/20260115000001_update_trending_unique_constraint.sql
@@ -1,0 +1,8 @@
+-- Update trending table unique constraint to allow same movie on different dates
+-- Drop the old unique constraint on movie_id only
+ALTER TABLE public.trending DROP CONSTRAINT IF EXISTS trending_movie_id_key;
+
+-- Add unique constraint on movie_id + date (cast created_at to date)
+-- This allows the same movie to appear in trending on different dates
+CREATE UNIQUE INDEX IF NOT EXISTS trending_movie_id_date_unique
+ON public.trending (movie_id, DATE(created_at));

--- a/supabase/migrations/20260115000001_update_trending_unique_constraint.sql
+++ b/supabase/migrations/20260115000001_update_trending_unique_constraint.sql
@@ -5,4 +5,4 @@ ALTER TABLE public.trending DROP CONSTRAINT IF EXISTS trending_movie_id_key;
 -- Add unique constraint on movie_id + date (cast created_at to date)
 -- This allows the same movie to appear in trending on different dates
 CREATE UNIQUE INDEX IF NOT EXISTS trending_movie_id_date_unique
-ON public.trending (movie_id, DATE(created_at));
+ON public.trending (movie_id, created_at);


### PR DESCRIPTION
- Updated refresh_trending function to fetch daily trending (day) instead of weekly (week)
- Added migration to update trending table unique constraint from movie_id only to (movie_id, date)
- This allows the same movie to appear in trending on different dates